### PR TITLE
HARMONY-388: Better consistency across Python repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+harmony-ntz
 
 # Spyder project settings
 .spyderproject

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,3 @@
-deps
-
-# Temporary output directories
-tmp*
-.DS_Store
-tmp
-config-*.json
-config.json
-
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -113,7 +104,6 @@ venv/
 ENV/
 env.bak/
 venv.bak/
-harmony-ntz
 
 # Spyder project settings
 .spyderproject
@@ -132,6 +122,14 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Temporary output directories
+tmp*
+.DS_Store
+tmp
+config-*.json
+config.json
+deps
 
 # Pycharm IDE
 .idea

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+.PHONY: install test lint build-image push-image build-test-image test-in-docker run-in-docker
+
+install:
+	pip install -r requirements/core.txt -r requirements/dev.txt
+
+test:
+	bin/test
+
+lint:
+	flake8 harmony_netcdf_to_zarr
+
+build-image:
+	LOCAL_SVCLIB_DIR=${LOCAL_SVCLIB_DIR} bin/build-image
+
+push-image:
+	bin/push-image
+
+build-test-image:
+	bin/build-test-image
+
+test-in-docker:
+	LOCAL_SVCLIB_DIR=${LOCAL_SVCLIB_DIR} bin/test-in-docker
+
+run-in-docker:
+	LOCAL_SVCLIB_DIR=${LOCAL_SVCLIB_DIR} bin/run-in-docker example/harmony-operation.json

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ and update the `.env` with the correct values.
 
 #### Python & Project Dependencies (Optional)
 
-If you would like to do local development outside of Docker, install Python, create a Python virtualenv,
+If you would like to do local development outside of Docker, install Python, create a Python virtual environment,
 and install the project dependencies.
 
 If you have [pyenv](https://github.com/pyenv/pyenv) and
@@ -48,15 +48,11 @@ create a virtualenv:
     $ pyenv version > .python-version
 
 The last step above creates a local .python-version file which will be automatically activated when cd'ing into the
-directory if pyenv-virtualenv has been initialized in your shell (See the pyenv-virtualenv docs linked above).
+directory if pyenv-virtualenv has been initialized in your shell (See the pyenv-virtualenv docs linked above). You can alternatively create your virtual environment using [Python's venv module](https://docs.python.org/3.7/library/venv.html).
 
 Install project dependencies:
 
     $ pip install -r requirements/core.txt -r requirements/dev.txt
-
-NOTE: All steps in this README which install dependencies need to be performed while on the NASA VPN
-in order to download and install the Harmony Service Lib, which is published on the
-[Nexus artifact repository](https://maven.earthdata.nasa.gov/).
 
 ### Development with Docker
 
@@ -83,7 +79,7 @@ the local clone of that Harmony Service Lib and any changes made to it:
     $ LOCAL_SVCLIB_DIR=../harmony-service-lib-py bin/test-in-docker
 
 Finally, run the service using an example Harmony operation request
-([example/harmony-operation.json](example/harmony-operation.json) as input.  This will reflect
+([example/harmony-operation.json](example/harmony-operation.json)) as input.  This will reflect
 local changes to this repo, but will not include local changes to the Harmony Service Lib.
 
     $ bin/run-in-docker example/harmony-operation.json
@@ -96,7 +92,7 @@ To run the example and also include local Harmony Service Lib changes:
 
 *Without local Harmony Service Lib changes*:
 
-Be sure your environment is pointed to the Minikube Docker daemon:
+If using Minikube, be sure your environment is pointed to the Minikube Docker daemon:
 
     $ eval $(minikube docker-env)
 

--- a/README.md
+++ b/README.md
@@ -44,11 +44,14 @@ Install project dependencies:
 
 ### Development with Docker
 
-If you'd rather not build the image locally (as instructed below), 
-you can simply pull the latest: `docker pull harmonyservices/netcdf-to-zarr`
+If you'd rather not build the image locally (as instructed below), you can simply pull the latest image: 
+    
+    $ docker pull harmonyservices/netcdf-to-zarr
 
 Some of the [Makefile](./Makefile) targets referenced below include an optional argument that allows us to use a local copy of 
-harmony-service-lib-py (which is useful for concurrent development): `$ make target-name LOCAL_SVCLIB_DIR=../harmony-service-lib-py`
+`harmony-service-lib-py` (which is useful for concurrent development): 
+    
+    $ make target-name LOCAL_SVCLIB_DIR=../harmony-service-lib-py
 
 #### Testing & Running the Service Independently
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ Install project dependencies:
 
 ### Development with Docker
 
+If you'd rather not build the image locally (as instructed below), 
+you can simply pull the latest: `docker pull harmonyservices/netcdf-to-zarr`
+
 #### Testing & Running the Service Independently
 
 To run unit tests, coverage reports, or run the service on a sample message _outside_ of the

--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ and update the `.env` with the correct values.
 
 #### Python & Project Dependencies (Optional)
 
-If you would like to do local development outside of Docker, install Python (3.7.4), and create a 
-[Python virtual environment](https://github.com/nasa/harmony-service-example/blob/main/ENVHELP.md).
+If you would like to do local development outside of Docker, install Python (3.7.4), and create a Python virtual environment.
 
 Install project dependencies:
 

--- a/README.md
+++ b/README.md
@@ -35,61 +35,43 @@ and update the `.env` with the correct values.
 
 #### Python & Project Dependencies (Optional)
 
-If you would like to do local development outside of Docker, install Python, create a Python virtual environment,
-and install the project dependencies.
-
-If you have [pyenv](https://github.com/pyenv/pyenv) and
-[pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv) installed (recommended), install Python and
-create a virtualenv:
-
-    $ pyenv install 3.7.4
-    $ pyenv virtualenv 3.7.4 harmony-ntz
-    $ pyenv activate harmony-ntz
-    $ pyenv version > .python-version
-
-The last step above creates a local .python-version file which will be automatically activated when cd'ing into the
-directory if pyenv-virtualenv has been initialized in your shell (See the pyenv-virtualenv docs linked above). You can alternatively create your virtual environment using [Python's venv module](https://docs.python.org/3.7/library/venv.html).
+If you would like to do local development outside of Docker, install Python (3.7.4), and create a 
+[Python virtual environment](https://github.com/nasa/harmony-service-example/blob/main/ENVHELP.md).
 
 Install project dependencies:
 
-    $ pip install -r requirements/core.txt -r requirements/dev.txt
+    $ make install
 
 ### Development with Docker
 
 If you'd rather not build the image locally (as instructed below), 
 you can simply pull the latest: `docker pull harmonyservices/netcdf-to-zarr`
 
+Some of the [Makefile](./Makefile) targets referenced below include an optional argument that allows us to use a local copy of 
+harmony-service-lib-py (which is useful for concurrent development): `$ make target-name LOCAL_SVCLIB_DIR=../harmony-service-lib-py`
+
 #### Testing & Running the Service Independently
 
 To run unit tests, coverage reports, or run the service on a sample message _outside_ of the
 entire Harmony stack, start by building new runtime and test images:
 
-*IMPORTANT*: Be sure to do these steps in a shell in which has *not* been updated to point to
+*IMPORTANT*: If Minikube is installed, be sure to do these steps in a shell in which has *not* been updated to point to
 the Minikube Docker daemon. This is usually done via a shell `eval` command. Doing so will
 cause tests and the service to fail due to limitations in Minikube.
 
-    $ bin/build-image
-    $ bin/build-test-image
+    $ make build-image
+    $ make build-test-image
 
 Run unit tests and generate overage reports. This will mount the local directory into the
 container and run the unit tests. So all tests will reflect local changes to the service.
 
-    $ bin/test-in-docker
-
-You may be concurrently making changes to the Harmony Service Lib. To run the unit tests using
-the local clone of that Harmony Service Lib and any changes made to it:
-
-    $ LOCAL_SVCLIB_DIR=../harmony-service-lib-py bin/test-in-docker
+    $ make test-in-docker
 
 Finally, run the service using an example Harmony operation request
 ([example/harmony-operation.json](example/harmony-operation.json)) as input.  This will reflect
 local changes to this repo, but will not include local changes to the Harmony Service Lib.
 
-    $ bin/run-in-docker example/harmony-operation.json
-
-To run the example and also include local Harmony Service Lib changes:
-
-    $ LOCAL_SVCLIB_DIR=../harmony-service-lib-py bin/run-in-docker example/harmony-operation.json
+    $ make run-in-docker
 
 #### Testing & Running the Service in Harmony
 
@@ -101,20 +83,9 @@ If using Minikube, be sure your environment is pointed to the Minikube Docker da
 
 Build the image:
 
-    $ bin/build-image
+    $ make build-image
 
 You can now run a workflow in your local Harmony stack and it will execute using this image.
-
-*With local Harmony Service Lib changes*:
-
-To run this service in Harmony *with* a local copy of the Service Lib, build
-the image, but specify the location of the local Harmony Service Lib clone:
-
-    $ LOCAL_SVCLIB_DIR=../harmony-service-lib-py bin/build-image
-
-You can now run a workflow in your local Harmony stack and it will execute using this image.
-Note that this also means that the image needs to be rebuilt (using the same command) to
-include any further changes to the Harmony Service Lib or this service.
 
 ### Development without Docker
 
@@ -122,7 +93,7 @@ include any further changes to the Harmony Service Lib or this service.
 
 Run tests with coverage reports:
 
-    $ bin/test
+    $ make test
 
 Run an example:
 

--- a/example/dotenv
+++ b/example/dotenv
@@ -20,3 +20,9 @@ USE_LOCALSTACK=true
 
 # The shared secret key used for encrypting & decrypting data in the Harmony message
 SHARED_SECRET_KEY=_THIS_IS_MY_32_CHARS_SECRET_KEY_
+
+# Set to 'true' if running Docker in Docker and the docker daemon is somewhere other than the current context
+DIND=true
+
+# Indicates where docker commands should find the docker daemon
+DOCKER_DAEMON_ADDR=host.docker.internal:2375


### PR DESCRIPTION
What follows are the acceptance criteria and what I found or did to address them. (I also spoke with Chris prior to submitting this PR.)
- Consistent python environment setup and use across the 3 repos 
  - For all but the harmony-service example, the READMEs were suggesting to use some combination of **pyenv**, **pyenv-virtualenv**, or **venv**. I tried to update the READMEs so that it was clear to the reader that all of these were acceptable tools.
- Either build **scripts** or **make** across the 3 repos
  - All of the regular (non-Docker service) Python module/lib repos (harmony-service-lib, harmony-py) use make files. All of the Docker/service-oriented repos (harmony-netcdf-to-zarr, harmony-service-example) use build scripts because they seem more conducive to the scripting logic needed to satisfy some of the more complex build logic. This seemed like a reasonably consistent solution (makefiles for pure libraries and build scripts for docker services).
- Consistent way of installing deps across the 3 repos
  -  All except one repo are using **pip** for installing dependencies in a fairly consistent manner, with one requirements file for dev, and one for core requirements. The only repo not following this pattern is the harmony-service-example, which uses **conda**. However, conda is a recommended way of installing one of the main dependencies of this repo (gdal) whereas pip is not (and is difficult to use in this instance from my experience). The use of conda, is also still compatible with the aforementioned recommended Python version manager and virtual env tools.
- Consistent linting across the 3 repos
  - All repos (except for harmony-service-example) use **flake8**. We could add **flake8** to harmony-service-example if desirable. I'm guessing it wasn't added due to the simplicity of the example.
- Consistent unit testing framework and execution across the 3 repos
  - I believe Patrick said there was another ticket addressing this.
- Consistent CI/CD across the 3 repos
  - Much of this seems to be adequately addressed by the recent transition to **GitHub** and related work.
- Update READMEs across the 3 repos to document the consistent tools, packages, and configuration for setting up a dev environment; dev environment does not presume editor
  -  I updated 3 READMEs to give more consistent suggestions on virtual environment setup. None of the dev environment setups assume the user has a specific editor.