### PR TITLE
DAS-1414 - Check input granule is NetCDF-4 via media type or extension.

### DIFF
--- a/harmony_netcdf_to_zarr/stac_utilities.py
+++ b/harmony_netcdf_to_zarr/stac_utilities.py
@@ -13,6 +13,7 @@ from harmony.util import bbox_to_geometry
 from pystac import Asset, Catalog, Item
 
 
+VALID_EXTENSIONS = ('.nc4', '.nc', '.h5', '.hdf5', '.hdf')
 VALID_MEDIA_TYPES = ['application/x-hdf5', 'application/x-netcdf',
                      'application/x-netcdf4']
 
@@ -38,9 +39,19 @@ def get_item_url(item: Item) -> Optional[str]:
 
     """
     return next((asset.href for asset in item.assets.values()
-                 if 'data' in (asset.roles or [])
-                 and asset.media_type in VALID_MEDIA_TYPES),
+                 if 'data' in (asset.roles or []) and is_netcdf_asset(asset)),
                 None)
+
+
+def is_netcdf_asset(asset: Asset) -> bool:
+    """ Check that a `pystac.Asset` is a valid NetCDF-4 granule. This can be
+        ascertained via either the media type or by checking the extension of
+        granule itself if that media type is absent.
+
+    """
+    return (asset.media_type in VALID_MEDIA_TYPES
+            or (asset.media_type is None
+                and asset.href.lower().endswith(VALID_EXTENSIONS)))
 
 
 def get_output_catalog(input_catalog: Catalog, zarr_root: str) -> Catalog:


### PR DESCRIPTION
This PR updates the NetCDF-to-Zarr service by ensuring that an input STAC asset with no media-type can be considered a valid NetCDF-4 input if the file extension matches a list of known options.

Presently, the `media_type` is only included for some requests (e.g., the Harmony Example L2 Data: C1233860183-EEDTEST), but not others (e.g., RSS SMAP L3 Sea Surface Salinity: C1234410736-POCLOUD).

**Example asset with media type:**

```json
{
  "data": {
    "href": "https://harmony.uat.earthdata.nasa.gov/service-results/harmony-uat-staging/public/harmony_example_l2/nc/000_00_000_africa.nc",
    "type": "application/x-netcdf4",
    "title": "000_00_000_africa.nc",
    "roles": [
      "data"
    ]
  }
}
```

**Example asset without media type:**

```json
{
  "data": {
    "href": "https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/SMAP_RSS_L3_SSS_SMI_8DAY-RUNNINGMEAN_V4/RSS_smap_SSS_L3_8day_running_2015_090_FNL_v04.0.nc",
    "title": "RSS_smap_SSS_L3_8day_running_2015_090_FNL_v04.0.nc",
    "description": "The base directory location for the granule.",
    "roles": [
      "data"
    ]
  }
}
```