### PR TITLE
DAS-1379 - Only aggregate temporal dimensions.

### DIFF
--- a/harmony_netcdf_to_zarr/mosaic_utilities.py
+++ b/harmony_netcdf_to_zarr/mosaic_utilities.py
@@ -227,6 +227,11 @@ class DimensionsMapping:
             elif any(are_inputs_temporal):
                 raise MixedDimensionTypeError(dimension_name)
             else:
+                # Temporarily comment out non-temporal aggregation as there are
+                # issues with Swath Projector output not always being on a
+                # perfectly spaced grid
+                pass
+                """
                 # All input granule dimensions with this path are non-temporal
                 # That means that the raw values are likely all the same units.
                 all_input_values = np.unique(
@@ -243,6 +248,7 @@ class DimensionsMapping:
                 self.output_dimensions[dimension_name] = self._get_output_dimension(
                     dimension_name, all_input_values, output_dimension_units
                 )
+                """
 
     def _get_temporal_output_dimension(self,
                                        dimension_inputs: Dict[str, DimensionInformation],

--- a/tests/unit/test_mosaic_utilities.py
+++ b/tests/unit/test_mosaic_utilities.py
@@ -120,12 +120,12 @@ class TestMosaicUtilities(TestCase):
                                                   dimensions=(dimension_name, ))
         dimension[:] = dimension_data
         dimension.setncattr('bounds', bounds_name)
-        dimension.setncattr('units', 'm')
+        dimension.setncattr('units', 'seconds since 2001-01-01T00:00:00')
 
         bounds = bounds_dataset.createVariable(bounds_name, bounds_data.dtype,
                                                dimensions=(dimension_name, 'nv'))
         bounds[:] = bounds_data
-        bounds.setncattr('units', 'm')
+        bounds.setncattr('units', 'seconds since 2001-01-01T00:00:00')
 
         return bounds_dataset
 
@@ -246,6 +246,12 @@ class TestMosaicUtilities(TestCase):
                                                'merra_two.nc4'])
 
             # Check the expected dimensions are in the output mapping.
+            # Note: aggregation of non-temporal dimensions has been disabled
+            # as the Swath Projector can have values with slight rounding
+            # errors in their output grid dimensions.
+            self.assertSetEqual(set(merra_mapping.output_dimensions.keys()),
+                                {'/time'})
+            """
             self.assertSetEqual(set(merra_mapping.output_dimensions.keys()),
                                 {'/time', '/latitude', '/longitude'})
 
@@ -268,6 +274,7 @@ class TestMosaicUtilities(TestCase):
             self.assertIsNone(merra_mapping.output_dimensions['/longitude'].time_unit)
             assert_array_equal(merra_mapping.output_dimensions['/longitude'].values,
                                self.lon_data)
+            """
 
             # Check the output time has correct values and units.
             self.assertEqual(merra_mapping.output_dimensions['/time'].units,
@@ -277,10 +284,12 @@ class TestMosaicUtilities(TestCase):
 
             # Check none of the output dimensions have bounds information, as
             # none of the inputs did.
+            """
             self.assertIsNone(merra_mapping.output_dimensions['/latitude'].bounds_values)
             self.assertIsNone(merra_mapping.output_dimensions['/latitude'].bounds_path)
             self.assertIsNone(merra_mapping.output_dimensions['/longitude'].bounds_values)
             self.assertIsNone(merra_mapping.output_dimensions['/longitude'].bounds_path)
+            """
             self.assertIsNone(merra_mapping.output_dimensions['/time'].bounds_values)
             self.assertIsNone(merra_mapping.output_dimensions['/time'].bounds_path)
 
@@ -290,6 +299,13 @@ class TestMosaicUtilities(TestCase):
                                                'merra_four.nc4'])
 
             # Check the expected dimensions are in the output mapping.
+            # Note: aggregation of non-temporal dimensions has been disabled
+            # as the Swath Projector can have values with slight rounding
+            # errors in their output grid dimensions.
+            self.assertSetEqual(set(merra_mapping.output_dimensions.keys()),
+                                {'/time'})
+
+            """
             self.assertSetEqual(set(merra_mapping.output_dimensions.keys()),
                                 {'/time', '/latitude', '/longitude'})
 
@@ -312,6 +328,7 @@ class TestMosaicUtilities(TestCase):
             self.assertIsNone(merra_mapping.output_dimensions['/longitude'].time_unit)
             assert_array_equal(merra_mapping.output_dimensions['/longitude'].values,
                                self.lon_data)
+            """
 
             # Check the output time has correct values and units.
             self.assertEqual(merra_mapping.output_dimensions['/time'].units,
@@ -321,10 +338,12 @@ class TestMosaicUtilities(TestCase):
 
             # Check none of the output dimensions have bounds information, as
             # none of the inputs did.
+            """
             self.assertIsNone(merra_mapping.output_dimensions['/latitude'].bounds_values)
             self.assertIsNone(merra_mapping.output_dimensions['/latitude'].bounds_path)
             self.assertIsNone(merra_mapping.output_dimensions['/longitude'].bounds_values)
             self.assertIsNone(merra_mapping.output_dimensions['/longitude'].bounds_path)
+            """
             self.assertIsNone(merra_mapping.output_dimensions['/time'].bounds_values)
             self.assertIsNone(merra_mapping.output_dimensions['/time'].bounds_path)
 
@@ -363,6 +382,12 @@ class TestMosaicUtilities(TestCase):
                                          'gpm_three.nc4'])
 
         # Check the expected dimensions are in the output mapping.
+        # Note: aggregation of non-temporal dimensions has been disabled
+        # as the Swath Projector can have values with slight rounding
+        # errors in their output grid dimensions.
+        self.assertSetEqual(set(gpm_mapping.output_dimensions.keys()),
+                            {'/time'})
+        """
         self.assertSetEqual(set(gpm_mapping.output_dimensions.keys()),
                             {'/time', '/latitude', '/longitude'})
 
@@ -385,6 +410,7 @@ class TestMosaicUtilities(TestCase):
         self.assertIsNone(gpm_mapping.output_dimensions['/longitude'].time_unit)
         assert_array_equal(gpm_mapping.output_dimensions['/longitude'].values,
                            self.lon_data)
+        """
 
         # Check the output time has correct values and units.
         self.assertEqual(gpm_mapping.output_dimensions['/time'].units,
@@ -394,10 +420,12 @@ class TestMosaicUtilities(TestCase):
 
         # Check none of the output dimensions have bounds information, as
         # none of the inputs did.
+        """
         self.assertIsNone(gpm_mapping.output_dimensions['/latitude'].bounds_values)
         self.assertIsNone(gpm_mapping.output_dimensions['/latitude'].bounds_path)
         self.assertIsNone(gpm_mapping.output_dimensions['/longitude'].bounds_values)
         self.assertIsNone(gpm_mapping.output_dimensions['/longitude'].bounds_path)
+        """
         self.assertIsNone(gpm_mapping.output_dimensions['/time'].bounds_values)
         self.assertIsNone(gpm_mapping.output_dimensions['/time'].bounds_path)
 
@@ -430,6 +458,12 @@ class TestMosaicUtilities(TestCase):
                                              'spatial_two.nc4'])
 
         # Check the expected dimensions are in the output mapping.
+        # Note: aggregation of non-temporal dimensions has been disabled
+        # as the Swath Projector can have values with slight rounding
+        # errors in their output grid dimensions.
+        self.assertSetEqual(set(spatial_mapping.output_dimensions.keys()),
+                            {'/time'})
+        """
         self.assertSetEqual(set(spatial_mapping.output_dimensions.keys()),
                             {'/time', '/latitude', '/longitude'})
 
@@ -452,6 +486,7 @@ class TestMosaicUtilities(TestCase):
         self.assertIsNone(spatial_mapping.output_dimensions['/longitude'].time_unit)
         assert_array_equal(spatial_mapping.output_dimensions['/longitude'].values,
                            expected_output_lon_data)
+        """
 
         # Check the output time has correct values and units.
         self.assertEqual(spatial_mapping.output_dimensions['/time'].units,
@@ -461,10 +496,12 @@ class TestMosaicUtilities(TestCase):
 
         # Check none of the output dimensions have bounds information, as
         # none of the inputs did.
+        """
         self.assertIsNone(spatial_mapping.output_dimensions['/latitude'].bounds_values)
         self.assertIsNone(spatial_mapping.output_dimensions['/latitude'].bounds_path)
         self.assertIsNone(spatial_mapping.output_dimensions['/longitude'].bounds_values)
         self.assertIsNone(spatial_mapping.output_dimensions['/longitude'].bounds_path)
+        """
         self.assertIsNone(spatial_mapping.output_dimensions['/time'].bounds_values)
         self.assertIsNone(spatial_mapping.output_dimensions['/time'].bounds_path)
 
@@ -721,9 +758,10 @@ class TestMosaicUtilities(TestCase):
                                                            '/dimension')
 
             self.assertEqual(bounds_dimension.dimension_path, '/dimension')
-            self.assertEqual(bounds_dimension.units, 'm')
-            self.assertIsNone(bounds_dimension.epoch)
-            self.assertIsNone(bounds_dimension.time_unit)
+            self.assertEqual(bounds_dimension.units,
+                             'seconds since 2001-01-01T00:00:00')
+            self.assertEqual(bounds_dimension.epoch, datetime(2001, 1, 1))
+            self.assertEqual(bounds_dimension.time_unit, timedelta(seconds=1))
             assert_array_equal(bounds_dimension.values, dimension_data)
             self.assertEqual(bounds_dimension.bounds_path, '/dimension_bnds')
             assert_array_equal(bounds_dimension.bounds_values, bounds_data)


### PR DESCRIPTION
This PR updates the `DimensionsMapping` class so that it will only try to aggregate temporal dimensions. Non-temporal dimension variables will now be treated like regular variables when writing out to a Zarr store.

This change was prompted by testing @chris-durbin conducted, where example L2 data was being processed by the Swath Projector, and then sent to the NetCDF-to-Zarr service. The issue here was that for some requested projections, the Swath Projector was writing output spatial grid values with float-point precision issues. This meant that the grids weren't _perfectly_ spaced. This meant the `DimensionsMapping.get_resolution` method found a really small resolution (of order the precision of a floating point variable) for these spatial dimensions, leading to _massive_ aggregated dimension arrays.

As TRT-121 only requires temporal aggregation, this PR updates the `DimensionsMapping` class to only aggregate temporal dimensions.