### PR TITLE
DAS-1438 - Ensure Zarr groups always use a ProcessSynchronizer.

### DIFF
--- a/docs/NetCDF-to-Zarr-Example-Usage.ipynb
+++ b/docs/NetCDF-to-Zarr-Example-Usage.ipynb
@@ -34,10 +34,13 @@
     "* `s3fs`: A package that enables interactions with items stored in AWS S3.\n",
     "* `matplotlib`: A package used extensively for plotting data in Python.\n",
     "* `xarray`: A package that can read and write data stored in a number of formats, including NetCDF-4 and Zarr.\n",
-    "* `netCDF4`: A package primarily used for interacting with NetCDF-4 files. `xarray` requires this to read a Zarr store.\n",
-    "* `zarr`: A package that interacts with Zarr stores. `xarray` will require this to read a Zarr store.\n",
     "\n",
-    "The packages above should be installed in the environment in which this notebook is running, prior to starting the notebook. They should be installed by default in the Openscapes 2i2c Jupyter Hub as part of the Corn development environment."
+    "Further packages required by the Python environment running this notebook include:\n",
+    "\n",
+    "* `netCDF4`: A package primarily used for interacting with NetCDF-4 files. This package is not explicitly imported below, but `xarray` requires this to read a Zarr store.\n",
+    "* `zarr`: A package that interacts with Zarr stores. Again, this package is not explicitly imported below, but `xarray` requires it to read a Zarr store.\n",
+    "\n",
+    "The packages in both lists above should be installed in the environment in which this notebook is running, prior to starting the notebook. They are included by default in the Openscapes 2i2c Jupyter Hub as part of the Corn development environment."
    ]
   },
   {

--- a/docs/NetCDF-to-Zarr-Example-Usage.ipynb
+++ b/docs/NetCDF-to-Zarr-Example-Usage.ipynb
@@ -37,7 +37,7 @@
     "* `netCDF4`: A package primarily used for interacting with NetCDF-4 files. `xarray` requires this to read a Zarr store.\n",
     "* `zarr`: A package that interacts with Zarr stores. `xarray` will require this to read a Zarr store.\n",
     "\n",
-    "The packages above should be installed in the environment in which this notebook is running, prior to starting the notebook. They should be installed by default in the Openscapes 2i2c Jupyer Hub as part of the Corn development environment."
+    "The packages above should be installed in the environment in which this notebook is running, prior to starting the notebook. They should be installed by default in the Openscapes 2i2c Jupyter Hub as part of the Corn development environment."
    ]
   },
   {
@@ -400,7 +400,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/docs/NetCDF-to-Zarr-Example-Usage.ipynb
+++ b/docs/NetCDF-to-Zarr-Example-Usage.ipynb
@@ -204,7 +204,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot = calibrated_dataset.blue_var.plot(cmap=plt.cm.coolwarm)"
+    "plot = calibrated_dataset.blue_var.plot(x='lon', y='lat', cmap=plt.cm.coolwarm)"
    ]
   },
   {
@@ -267,7 +267,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot = raw_dataset.blue_var.plot(cmap=plt.cm.coolwarm)"
+    "plot = raw_dataset.blue_var.plot(x='lon', y='lat', cmap=plt.cm.coolwarm)"
    ]
   },
   {

--- a/docs/NetCDF-to-Zarr-Example-Usage.ipynb
+++ b/docs/NetCDF-to-Zarr-Example-Usage.ipynb
@@ -34,6 +34,8 @@
     "* `s3fs`: A package that enables interactions with items stored in AWS S3.\n",
     "* `matplotlib`: A package used extensively for plotting data in Python.\n",
     "* `xarray`: A package that can read and write data stored in a number of formats, including NetCDF-4 and Zarr.\n",
+    "* `netCDF4`: A package primarily used for interacting with NetCDF-4 files. `xarray` requires this to read a Zarr store.\n",
+    "* `zarr`: A package that interacts with Zarr stores. `xarray` will require this to read a Zarr store.\n",
     "\n",
     "The packages above should be installed in the environment in which this notebook is running, prior to starting the notebook. They should be installed by default in the Openscapes 2i2c Jupyer Hub as part of the Corn development environment."
    ]
@@ -123,7 +125,8 @@
     "example_l2_collection = Collection(id='C1233860183-EEDTEST')\n",
     "\n",
     "# Specify a request to create Zarr output for one granule in the collection:\n",
-    "single_granule_request = Request(collection=example_l2_collection, format='application/x-zarr', max_results=1)\n",
+    "single_granule_request = Request(collection=example_l2_collection, format='application/x-zarr',\n",
+    "                                 granule_id='G1233860549-EEDTEST')\n",
     "\n",
     "# Submit the request and wait for it to complete:\n",
     "single_granule_job_id = harmony_client.submit(single_granule_request)\n",
@@ -397,7 +400,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/harmony_netcdf_to_zarr/mosaic_utilities.py
+++ b/harmony_netcdf_to_zarr/mosaic_utilities.py
@@ -154,6 +154,7 @@ class DimensionsMapping:
         self.input_paths = input_paths
         self.input_dimensions = {}
         self.output_dimensions = {}
+        self.output_bounds = {}
         self._map_input_dimensions()
         self._aggregate_output_dimensions()
 
@@ -224,6 +225,7 @@ class DimensionsMapping:
                 self.output_dimensions[dimension_name] = self._get_temporal_output_dimension(
                     dimension_inputs, dimension_name
                 )
+                self._map_output_bounds(self.output_dimensions[dimension_name])
             elif any(are_inputs_temporal):
                 raise MixedDimensionTypeError(dimension_name)
             else:
@@ -248,6 +250,7 @@ class DimensionsMapping:
                 self.output_dimensions[dimension_name] = self._get_output_dimension(
                     dimension_name, all_input_values, output_dimension_units
                 )
+                self._map_output_bounds(self.output_dimensions[dimension_name])
                 """
 
     def _get_temporal_output_dimension(self,
@@ -378,6 +381,15 @@ class DimensionsMapping:
             bounds_values = None
 
         return bounds_path, bounds_values
+
+    def _map_output_bounds(self, dimension: DimensionInformation):
+        """ Create a mapping from the fully resolved bounds variable path to
+            the fully resolved dimension variable path. This allows for easier
+            information retrieval when only the bounds path is known.
+
+        """
+        if dimension.bounds_path is not None:
+            self.output_bounds[dimension.bounds_path] = dimension.dimension_path
 
 
 def get_nc_attribute(

--- a/harmony_netcdf_to_zarr/mosaic_utilities.py
+++ b/harmony_netcdf_to_zarr/mosaic_utilities.py
@@ -232,26 +232,24 @@ class DimensionsMapping:
                 # Temporarily comment out non-temporal aggregation as there are
                 # issues with Swath Projector output not always being on a
                 # perfectly spaced grid
-                pass
-                """
                 # All input granule dimensions with this path are non-temporal
                 # That means that the raw values are likely all the same units.
-                all_input_values = np.unique(
-                    np.concatenate([dimension_input.get_values()
-                                    for dimension_input
-                                    in dimension_inputs.values()])
-                )
+                # all_input_values = np.unique(
+                #     np.concatenate([dimension_input.get_values()
+                #                     for dimension_input
+                #                     in dimension_inputs.values()])
+                # )
 
                 # Because it is assumed the units are the same for all inputs,
                 # use the `units` metadata from the first input granule as
                 # the value for the aggregated output dimension.
-                output_dimension_units = next(iter(dimension_inputs.values())).units
+                # output_dimension_units = next(iter(dimension_inputs.values())).units
 
-                self.output_dimensions[dimension_name] = self._get_output_dimension(
-                    dimension_name, all_input_values, output_dimension_units
-                )
-                self._map_output_bounds(self.output_dimensions[dimension_name])
-                """
+                # self.output_dimensions[dimension_name] = self._get_output_dimension(
+                #     dimension_name, all_input_values, output_dimension_units
+                # )
+                # self._map_output_bounds(self.output_dimensions[dimension_name])
+                pass
 
     def _get_temporal_output_dimension(self,
                                        dimension_inputs: Dict[str, DimensionInformation],

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -1,6 +1,5 @@
 """ Unit tests for the `harmony_netcdf_to_zarr.adapter` module. """
 from datetime import datetime
-from unittest.mock import patch
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -234,7 +234,7 @@ class TestConvert(TestCase):
         # gridded variables.
         self.assertEqual(mock_copy_variable.call_count, 16)
 
-        # The fourth argument in the call to `__copy_variable` is the variable
+        # The third argument in the call to `__copy_variable` is the variable
         # name.
         all_output_variables = {call[0][2]
                                 for call

--- a/tests/unit/test_download_utilities.py
+++ b/tests/unit/test_download_utilities.py
@@ -1,14 +1,11 @@
 """ Unit tests for the `harmony_netcdf_to_zarr.download_utilities` module. """
 from logging import getLogger
-from multiprocessing import Queue
-from multiprocessing.managers import Namespace
 from os import remove as remove_file
 from os.path import dirname, exists as file_exists, join as join_path
 from pathlib import Path
 from shutil import rmtree
 from tempfile import mkdtemp
 from unittest import TestCase
-from unittest.mock import patch
 
 from harmony.util import config
 

--- a/tests/unit/test_mosaic_utilities.py
+++ b/tests/unit/test_mosaic_utilities.py
@@ -459,35 +459,33 @@ class TestMosaicUtilities(TestCase):
         # Note: aggregation of non-temporal dimensions has been disabled
         # as the Swath Projector can have values with slight rounding
         # errors in their output grid dimensions.
-        self.assertSetEqual(set(spatial_mapping.output_dimensions.keys()),
-                            {'/time'})
-        """
-        expected_output_lat_data = np.array([-10, -5, 0, 5, 10, 15])
-        expected_output_lon_data = np.array([1, 2, 3, 4, 5, 6, 7])
+        # self.assertSetEqual(set(spatial_mapping.output_dimensions.keys()),
+        #                     {'/time'})
+        # expected_output_lat_data = np.array([-10, -5, 0, 5, 10, 15])
+        # expected_output_lon_data = np.array([1, 2, 3, 4, 5, 6, 7])
 
-        self.assertSetEqual(set(spatial_mapping.output_dimensions.keys()),
-                            {'/time', '/latitude', '/longitude'})
+        # self.assertSetEqual(set(spatial_mapping.output_dimensions.keys()),
+        #                     {'/time', '/latitude', '/longitude'})
 
         # Check the output latitude has correct values and units.
-        self.assertEqual(
-            spatial_mapping.output_dimensions['/latitude'].units,
-            'degrees_north'
-        )
-        self.assertIsNone(spatial_mapping.output_dimensions['/latitude'].epoch)
-        self.assertIsNone(spatial_mapping.output_dimensions['/latitude'].time_unit)
-        assert_array_equal(spatial_mapping.output_dimensions['/latitude'].values,
-                           expected_output_lat_data)
+        # self.assertEqual(
+        #     spatial_mapping.output_dimensions['/latitude'].units,
+        #     'degrees_north'
+        # )
+        # self.assertIsNone(spatial_mapping.output_dimensions['/latitude'].epoch)
+        # self.assertIsNone(spatial_mapping.output_dimensions['/latitude'].time_unit)
+        # assert_array_equal(spatial_mapping.output_dimensions['/latitude'].values,
+        #                    expected_output_lat_data)
 
         # Check the output longitude has correct values and units.
-        self.assertEqual(
-            spatial_mapping.output_dimensions['/longitude'].units,
-            'degrees_east'
-        )
-        self.assertIsNone(spatial_mapping.output_dimensions['/longitude'].epoch)
-        self.assertIsNone(spatial_mapping.output_dimensions['/longitude'].time_unit)
-        assert_array_equal(spatial_mapping.output_dimensions['/longitude'].values,
-                           expected_output_lon_data)
-        """
+        # self.assertEqual(
+        #     spatial_mapping.output_dimensions['/longitude'].units,
+        #     'degrees_east'
+        # )
+        # self.assertIsNone(spatial_mapping.output_dimensions['/longitude'].epoch)
+        # self.assertIsNone(spatial_mapping.output_dimensions['/longitude'].time_unit)
+        # assert_array_equal(spatial_mapping.output_dimensions['/longitude'].values,
+        #                    expected_output_lon_data)
 
         # Check the output time has correct values and units.
         self.assertEqual(spatial_mapping.output_dimensions['/time'].units,

--- a/tests/unit/test_mosaic_utilities.py
+++ b/tests/unit/test_mosaic_utilities.py
@@ -441,8 +441,6 @@ class TestMosaicUtilities(TestCase):
         lat_data_two = np.array([10, 15])
         lon_data_one = np.array([1, 2, 3])
         lon_data_two = np.array([6, 7])
-        expected_output_lat_data = np.array([-10, -5, 0, 5, 10, 15])
-        expected_output_lon_data = np.array([1, 2, 3, 4, 5, 6, 7])
 
         dataset_one = self.generate_netcdf_input(
             'spatial_one.nc4', lat_data_one, lon_data_one,
@@ -464,6 +462,9 @@ class TestMosaicUtilities(TestCase):
         self.assertSetEqual(set(spatial_mapping.output_dimensions.keys()),
                             {'/time'})
         """
+        expected_output_lat_data = np.array([-10, -5, 0, 5, 10, 15])
+        expected_output_lon_data = np.array([1, 2, 3, 4, 5, 6, 7])
+
         self.assertSetEqual(set(spatial_mapping.output_dimensions.keys()),
                             {'/time', '/latitude', '/longitude'})
 
@@ -555,6 +556,7 @@ class TestMosaicUtilities(TestCase):
                                                [3.5, 4.5],
                                                [4.5, 5.5]])
 
+            self.assertDictEqual(mapping.output_bounds, {'/dim_bnds': '/dim'})
             assert_array_equal(mapping.output_dimensions['/dim'].values,
                                np.array([0, 1, 2, 3, 4, 5]))
             self.assertEqual(mapping.output_dimensions['/dim'].bounds_path,


### PR DESCRIPTION
This PR updates the NetCDF-to-Zarr service to mitigate a couple of intermittent issues arising from using parallel processes:

* The Zarr Group objects weren't always using a `ProcessSynchronizer`. This meant that, when writing attributes, there were occasional conflicts where two processes would try to write metadata attributes for the same group at the same time.
* By setting the `synchronizer` property of the root group in the Zarr output and using the `require_dataset` or `require_group` class methods, that synchronizer is passed on to the child groups and variables, meaning it doesn't have to be specified in those calls.
* The metadata attributes for aggregated variables are now only written by the `__copy_attrs` function. Previously, the `units` metadata attribute was written earlier, when the aggregated data array was written. This was also, for some reason, leading to process conflicts when reading the existing metadata attributes.

To try and verify the changes mitigate the intermittent issues, I've built a Docker image from this branch, and run the request that triggers issues a lot (> 35 times). I've still not triggered a failure, whereas the same request in UAT fails 20 - 40% of the time.

Other minor change:

* Updating the documentation notebook to refer to a granule that definitely has the described `scale_factor` and `add_offset` attributes.