### PR TITLE
DAS-1438 - Ensure zero-dimensional variables, like a CRS, resolve full paths.

### DIFF
--- a/harmony_netcdf_to_zarr/convert.py
+++ b/harmony_netcdf_to_zarr/convert.py
@@ -295,6 +295,8 @@ def __copy_variable(netcdf_variable: NetCDFVariable, zarr_group: ZarrGroup,
             the input source data.
 
     """
+    resolved_variable_name = resolve_reference_path(netcdf_variable,
+                                                    variable_name)
     # create zarr group/dataset
     chunks = netcdf_variable.chunking()
     if chunks == 'contiguous' or chunks is None:
@@ -325,8 +327,6 @@ def __copy_variable(netcdf_variable: NetCDFVariable, zarr_group: ZarrGroup,
                                                    dtype=dtype,
                                                    fill_value=fill_value)
 
-        resolved_variable_name = resolve_reference_path(netcdf_variable,
-                                                        variable_name)
         if resolved_variable_name not in aggregated_dimensions:
             # For a non-aggregated dimension, insert input granule data
             __insert_data_slice(netcdf_variable, zarr_variable,


### PR DESCRIPTION
This PR updates the NetCDF-to-Zarr service to ensure that all types of variables will define `resolved_variable_name` in the `__copy_variable` function.

Prior to this change, the following request was failing:

```
/harmony_example_l2/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?maxResults=1&outputCrs=%2Bproj%3Dlcc%20%2Blat_1%3D43%20%2Blat_2%3D62%20%2Blat_0%3D30%20%2Blon_0%3D10%20%2Bx_0%3D0%20%2By_0%3D0%20%2Bellps%3Dintl%20%2Bunits%3Dm%20no_defs&interpolation=near&scaleExtent=-7000000&scaleExtent=1000000&scaleExtent=8000000&scaleExtent=8000000&format=application%2Fx-zarr
```

This request chains together the Swath Projector and the NetCDF-to-Zarr service. The output from the Swath Projector has a CRS variable `/lambert_conformal_conic`. These variables have metadata attributes, but not data values. This meant that the following condition was being satisfied:

```
if not chunks and len(netcdf_variable.dimensions) == 0
```

As such, the declaration of `resolved_variable_name` was being missed in the alternative code branch. `resolved_variable_name` is needed later within the function, regardless of whether the input NetCDF-4 variable has chunks and zero dimensions or not.

This PR moves the `resolved_variable_name` declaration to the start of the function, so that it will always occur.

Thanks to @chris-durbin for finding this error. (Our tests to-date had not included a granule with a CRS variable)