### PR TITLE
HARMONY-1178: Handle paged STAC catalog input

### DIFF
--- a/harmony_netcdf_to_zarr/adapter.py
+++ b/harmony_netcdf_to_zarr/adapter.py
@@ -85,7 +85,7 @@ class NetCDFToZarrAdapter(BaseHarmonyAdapter):
         """
         workdir = mkdtemp()
         try:
-            items = list(self.catalog.get_items())
+            items = list(self.get_all_catalog_items(self.catalog))
             netcdf_urls = get_netcdf_urls(items)
 
             local_file_paths = download_granules(netcdf_urls, workdir,

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -1,5 +1,5 @@
 boto3 ~= 1.14
-git+https://github.com/nasa/harmony-service-lib-py@main#egg=harmony-service-lib
+harmony-service-lib ~= 1.0.16
 netCDF4 ~= 1.5
 numpy ~= 1.21.0
 python-dateutil ~= 2.8.2


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1178

## Description
Adds handling of paged STAC catalog (catalogs with 'next' and 'prev' links) input.

## Local Test Steps
1. Follow the build instructions the README.md to build the harmony/netcdf-to-zarr image, i.e, `make build`
2. Add `AGGREGATE_STAC_CATALOG_MAX_PAGE_SIZE=2` to your local .env file and restart Harmony
3. Execute the following query:
http://localhost:3000/C1234410736-POCLOUD/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?format=application%2Fx-zarr&maxResults=10&concatenate=true
4. Refresh the status page until the job completes to get the link to the single zarr file then use the AWS CLI to verify that it is in S3
```
aws --endpoint-url=http://localhost:4572 s3 ls s3://local-staging-bucket/public/harmony/netcdf-to-zarr/<job ID>/C1234410736-POCLOUD_merged.zarr/
```

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] ~Documentation updated (if needed)~