### PR TITLE
HARMONY-1189 - Update harmony-service-lib dependency to 1.0.20.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## Description
+
+A short description of the changes in this PR.
+
+## Jira Issue ID
+
+## Local Test Steps
+
+## PR Acceptance Checklist
+* [ ] Jira ticket acceptance criteria met.
+* [ ] Tests added/updated and passing.
+* [ ] Documentation updated (if needed).

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -1,5 +1,5 @@
 boto3 ~= 1.14
-harmony-service-lib ~= 1.0.16
+harmony-service-lib ~= 1.0.20
 netCDF4 ~= 1.5
 numpy ~= 1.21.0
 python-dateutil ~= 2.8.2


### PR DESCRIPTION
This PR updates the NetCDF-to-Zarr service to use at least `harmony-service-lib ~= 1.0.20`, so that the service is compatible with the updated STAC handling within Harmony.

As a bonus, I've added a PR template, that will take effect following the merge of this PR.

## Testing:

The unit tests continue to pass (I ran them locally and that was the case).