### PR TITLE
DAS-1536 - Ensure raised exception messages are correctly tested.

### DIFF
--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -364,10 +364,10 @@ class TestAdapter(TestCase):
                   stac_catalog, '--harmony-metadata-dir', self.metadata_dir],
                  config=self.config)
 
-            self.assertTrue(
-                str(context_manager.exception).startswith(
-                    'Could not create Zarr output:'
-                )
+        self.assertTrue(
+            context_manager.exception.message.startswith(
+                'Could not create Zarr output:'
             )
+        )
 
         os.remove(filename)

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -192,6 +192,7 @@ class TestNetCDFToZarrAdapter(TestCase):
 
         """
         message_content = self.base_message_content.copy()
+        message_content['format'] = {'mime': 'application/x-zarr'}
         harmony_message = Message(message_content)
         harmony_adapter = NetCDFToZarrAdapter(harmony_message,
                                               config=self.harmony_config)
@@ -201,7 +202,7 @@ class TestNetCDFToZarrAdapter(TestCase):
 
         self.assertEqual(
             context_manager.exception.message,
-            'Request failed due to an incorrect service workflow'
+            'Invoking NetCDF-to-Zarr without STAC catalog is not supported.'
         )
 
     @patch('harmony_netcdf_to_zarr.adapter.get_output_catalog')

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -146,10 +146,11 @@ class TestNetCDFToZarrAdapter(TestCase):
 
             with self.assertRaises(ZarrException) as context_manager:
                 harmony_adapter.invoke()
-                self.assertEqual(
-                    str(context_manager.exception),
-                    'Request failed due to an incorrect service workflow'
-                )
+
+            self.assertEqual(
+                context_manager.exception.message,
+                'Request failed due to an incorrect service workflow'
+            )
 
         with self.subTest('No mime attribute in message.format'):
             message_content = self.base_message_content.copy()
@@ -161,10 +162,11 @@ class TestNetCDFToZarrAdapter(TestCase):
 
             with self.assertRaises(ZarrException) as context_manager:
                 harmony_adapter.invoke()
-                self.assertEqual(
-                    str(context_manager.exception),
-                    'Request failed due to an incorrect service workflow'
-                )
+
+            self.assertEqual(
+                context_manager.exception.message,
+                'Request failed due to an incorrect service workflow'
+            )
 
         with self.subTest('No format attribute in message'):
             message_content = self.base_message_content.copy()
@@ -175,10 +177,11 @@ class TestNetCDFToZarrAdapter(TestCase):
 
             with self.assertRaises(ZarrException) as context_manager:
                 harmony_adapter.invoke()
-                self.assertEqual(
-                    str(context_manager.exception),
-                    'Request failed due to an incorrect service workflow'
-                )
+
+            self.assertEqual(
+                context_manager.exception.message,
+                'Request failed due to an incorrect service workflow'
+            )
 
     @patch('harmony_netcdf_to_zarr.adapter.make_localstack_s3fs')
     @patch.object(NetCDFToZarrAdapter, 'process_items_many_to_one')
@@ -195,10 +198,11 @@ class TestNetCDFToZarrAdapter(TestCase):
 
         with self.assertRaises(ZarrException) as context_manager:
             harmony_adapter.invoke()
-            self.assertEqual(
-                str(context_manager.exception),
-                'Invoking NetCDF-to-Zarr without STAC catalog is not supported.'
-            )
+
+        self.assertEqual(
+            context_manager.exception.message,
+            'Request failed due to an incorrect service workflow'
+        )
 
     @patch('harmony_netcdf_to_zarr.adapter.get_output_catalog')
     @patch('harmony_netcdf_to_zarr.adapter.netcdf_to_zarr')

--- a/tests/unit/test_download_utilities.py
+++ b/tests/unit/test_download_utilities.py
@@ -71,6 +71,6 @@ class TestDownloadUtilities(TestCase):
                               self.access_token, self.harmony_config,
                               self.logger)
 
-            self.assertTrue(str(context_manager.exception).startswith(
-                'Unable to download a url of unknown type'
-            ))
+        self.assertTrue(str(context_manager.exception).startswith(
+            'Download failed: Unable to download a url of unknown type'
+        ))


### PR DESCRIPTION
## Description

This PR arises from a mistake discovered during DAS-1536. For `unittest` to correctly check the message of a raises assertion that is caught by a `TestCase.assertRaises` statement, any check on that exception message needs to occur outside of the `TestCase.assertRaises` context manager block. If placed within the context manager, the assertion will silently not happen.

This PR updates all affected tests in the NetCDF-to-Zarr repository test suite.

## Jira Issue ID

DAS-1536 - (well "discovered while testing DAS-1536")

## Local Test Steps

* Pull this branch.
* Create a local Python environment with the dependencies listed in `requirements/core.txt` and `requirements/dev.txt`.
* Run `make test`
* This should complete and have no test failures.
