### PR TITLE
DAS-1685 - Ensure single granule requests don't attempt aggregation.

### DIFF
--- a/harmony_netcdf_to_zarr/convert.py
+++ b/harmony_netcdf_to_zarr/convert.py
@@ -78,11 +78,14 @@ def mosaic_to_zarr(input_granules: List[str], zarr_store: Union[FSMap, str],
 
     # Write dimension information from DimensionsMapping (including bounds)
     # Store list of aggregated dimensions/variables to avoid writing them again
+    # Aggregation will only occur for multiple granule requests that set
+    # `concatenate=true`.
     dim_mapping = DimensionsMapping(input_granules)
     variable_chunk_metadata = granule_chunk_shapes(input_granules[0])
 
-    aggregated_dimensions = __copy_aggregated_dimensions(dim_mapping,
-                                                         zarr_store, variable_chunk_metadata)
+    aggregated_dimensions = __copy_aggregated_dimensions(
+        dim_mapping, zarr_store, variable_chunk_metadata
+    )
 
     if process_count is None:
         process_count = min(cpu_count(), len(input_granules))

--- a/harmony_netcdf_to_zarr/mosaic_utilities.py
+++ b/harmony_netcdf_to_zarr/mosaic_utilities.py
@@ -148,10 +148,10 @@ class DimensionsMapping:
         of the input NetCDF-4 granules. This class also will produce single,
         aggregated arrays and metadata (if required) for the output Zarr
         object. Note - output aggregated arrays are only calculated if there is
-        only one input granule. This ensures that the NetCDF-to-Zarr service is
-        compatible with single-granule requests, where those granules contain
-        irregular dimensions that would otherwise be converted to a dimension
-        with consistent spacing between all pixels.
+        more than one input granule. This ensures that the NetCDF-to-Zarr
+        service is compatible with single-granule requests, where those
+        granules contain irregular dimensions that would otherwise be converted
+        to a dimension with consistent spacing between all pixels.
 
     """
     def __init__(self, input_paths: List[str]):

--- a/harmony_netcdf_to_zarr/mosaic_utilities.py
+++ b/harmony_netcdf_to_zarr/mosaic_utilities.py
@@ -147,7 +147,7 @@ class DimensionsMapping:
     """ A class containing the information for all dimensions contained in each
         of the input NetCDF-4 granules. This class also will produce single,
         aggregated arrays and metadata (if required) for the output Zarr
-        object. Note - output aggregated arrays are note calculated if there is
+        object. Note - output aggregated arrays are only calculated if there is
         only one input granule. This ensures that the NetCDF-to-Zarr service is
         compatible with single-granule requests, where those granules contain
         irregular dimensions that would otherwise be converted to a dimension

--- a/harmony_netcdf_to_zarr/mosaic_utilities.py
+++ b/harmony_netcdf_to_zarr/mosaic_utilities.py
@@ -147,7 +147,11 @@ class DimensionsMapping:
     """ A class containing the information for all dimensions contained in each
         of the input NetCDF-4 granules. This class also will produce single,
         aggregated arrays and metadata (if required) for the output Zarr
-        object.
+        object. Note - output aggregated arrays are note calculated if there is
+        only one input granule. This ensures that the NetCDF-to-Zarr service is
+        compatible with single-granule requests, where those granules contain
+        irregular dimensions that would otherwise be converted to a dimension
+        with consistent spacing between all pixels.
 
     """
     def __init__(self, input_paths: List[str]):
@@ -156,7 +160,10 @@ class DimensionsMapping:
         self.output_dimensions = {}
         self.output_bounds = {}
         self._map_input_dimensions()
-        self._aggregate_output_dimensions()
+
+        if len(self.input_paths) > 1:
+            # Only calculate regular, aggregated dimensions for multiple inputs
+            self._aggregate_output_dimensions()
 
     def _map_input_dimensions(self):
         """ Iterate through all input files and extract their dimension

--- a/tests/unit/test_mosaic_utilities.py
+++ b/tests/unit/test_mosaic_utilities.py
@@ -220,10 +220,10 @@ class TestMosaicUtilities(TestCase):
         input_datasets = [self.test_dataset_path]
         dimensions_mapping = DimensionsMapping(input_datasets)
 
-        # Ensure both NetCDF-4 datasets were parsed:
-        mock_dataset.assert_called_once_with(self.test_dataset.path, 'r')
+        # Ensure the NetCDF-4 dataset was parsed:
+        mock_dataset.assert_called_once_with(self.test_dataset_path, 'r')
 
-        # Ensure all dimensions are detected from input datasets:
+        # Ensure all dimensions are detected from the input dataset:
         expected_dimensions = {'/latitude', '/longitude', '/time'}
         self.assertSetEqual(set(dimensions_mapping.input_dimensions.keys()),
                             expected_dimensions)


### PR DESCRIPTION
## Description

This PR attempts to fix a regression in the NetCDF-to-Zarr service, where single granule inputs with irregularly spaced time dimensions had begun to fail. The underlying issue is:

* The `DimensionsMapping` class was calculating an aggregated (regularly spaced) temporal dimension for the granule.
* The function that inserts data slices assumes that an input granule fills a contiguous region of the output Zarr store (which with the finer grid, it no longer did).

The fix here is to not derive aggregated dimensions for request inputs if there is only a single granule being given to the Docker image. This will mean that when writing the output, the any dimension that would be aggregated in a multiple-granule Zarr store is now treated like any other variable and written like-for-like.

## Jira Issue ID

DAS-1685

## Local Test Steps

* Pull this branch to your local repository.
* Run `bin/build-image`.
* In the Harmony repository, run `bin/restart-services`, to update your local Harmony instance.
* Run the following request - it should succeed: http://localhost:3000/C1256121622-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?forceAsync=true&format=application%2Fx-zarr 
* Run the following request - it should succeed and still produce a single Zarr store output: http://localhost:3000/C1245618475-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?forceAsync=true&maxResults=50&concatenate=true&format=application%2Fx-zarr

## PR Acceptance Checklist
* [x] Jira ticket acceptance criteria met.
* [x] Tests added/updated and passing.
* ~~Documentation updated (if needed).~~
