### PR TITLE
give compute_chunksize a side effect to prevent pickling error in testing end to end

### DIFF
--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -237,6 +237,12 @@ class TestAdapter(TestCase):
         mock_make_s3fs_adapter.return_value.get_mapper.return_value = local_zarr
         mock_make_s3fs.return_value.get_mapper.return_value = local_zarr
 
+        def chunksize_side_effect(input_array_size, _):
+            """ Set compute_chunksize mock to return the input array size """
+            return list(input_array_size)
+
+        mock_compute_chunksize.side_effect = chunksize_side_effect
+
         # Create mock data. Science variable and time for second NetCDF-4 must
         # be different to first to allow mosaic testing.
         first_file = create_full_dataset()

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -22,9 +22,11 @@ from harmony.message import Message
 from harmony_netcdf_to_zarr.__main__ import main
 from harmony_netcdf_to_zarr.adapter import NetCDFToZarrAdapter, ZarrException
 
-from .util.file_creation import (ROOT_METADATA_VALUES, create_full_dataset,
-                                 create_input_catalog, create_large_dataset)
-from .util.harmony_interaction import MOCK_ENV, mock_message
+from tests.util.file_creation import (ROOT_METADATA_VALUES,
+                                      create_full_dataset,
+                                      create_input_catalog,
+                                      create_large_dataset)
+from tests.util.harmony_interaction import MOCK_ENV, mock_message
 
 logger = logging.getLogger()
 


### PR DESCRIPTION
_pickle.PicklingError: Can't pickle <class 'unittest.mock.MagicMock'>: it's not the same object as unittest.mock.MagicMock

Without a side effect, that mock was unable to be pickled. 

DAS-bugfix

## Description

A short description of the changes in this PR.

Change the setup for one test to ensure tests work on mac and linux (or local and docker)

## Jira Issue ID

## Local Test Steps

pull the branch
activate a local conda environment with the core and dev requirements installed 
`make test` should pass without errors locally

## PR Acceptance Checklist
* [ n/a ] Jira ticket acceptance criteria met.
* [ X ] Tests added/updated and passing.
* [ N/a ] Documentation updated (if needed).
