### PR TITLE
DAS-1695 Ensure correct metadata is written to store.

### DIFF
--- a/harmony_netcdf_to_zarr/convert.py
+++ b/harmony_netcdf_to_zarr/convert.py
@@ -130,7 +130,7 @@ def mosaic_to_zarr(input_granules: List[str], zarr_store: Union[FSMap, str],
 def _finalize_metadata(store: MutableMapping) -> None:
     """Safely prepare a store for consolidated metadata reading.
 
-    This function forces a "flush" fo the input store before calling zarr's
+    This function forces a "flush" of the input store before calling zarr's
     consolidate_metadata function.  This ensures that whatever store handle is
     passed to this routine has the most up to date information before
     consolidation.

--- a/harmony_netcdf_to_zarr/mosaic_utilities.py
+++ b/harmony_netcdf_to_zarr/mosaic_utilities.py
@@ -10,7 +10,7 @@ from dateutil.parser import parse as parse_datetime
 from netCDF4 import Dataset, Group, Variable
 import numpy as np
 
-from .exceptions import MixedDimensionTypeError
+from harmony_netcdf_to_zarr.exceptions import MixedDimensionTypeError
 
 
 BoundsTuple = Tuple[Optional[str], Optional[np.ndarray]]


### PR DESCRIPTION
## Description

Calling consolidate_metadata on the zarr_store in the service was yielding incorrect/incomplete metadata depending on when the function was called.


## Jira Issue ID

[DAS-1695](https://bugs.earthdata.nasa.gov/browse/DAS-1695)

## Local Test Steps

There are no unit tests because this is working around behavior discovered in
using the service.

There will be an integration test later that will verify that correct metadata
is present and the file can be opened with consolidated metadata.

To test in SIT: make a request for concatenated netcdf-to-zarr output for both 1 and 2 granules

http://harmony.sit.earthdata.nasa.gov/C1245618475-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?forceAsync=true&maxResults=1&concatenate=true&format=application%2Fx-zarr

http://harmony.sit.earthdata.nasa.gov/C1245618475-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?forceAsync=true&maxResults=2&concatenate=true&format=application%2Fx-zarr

Wait for them to finish processing.

Download the .zmetadata file from the returned zarr_store.
The returned zarr store is in the links array with type "application/x-zarr"
and you can copy the file to your local system if you have aws commandline installed with

```
AWS_PROFILE=<yoursitprofile> aws s3 cp s3://<bucket>/<path>/<zarrname>.zarr/.zmetadata zmetadata.json
```

examine this zmetadata.json file ensure there is a "metadata" key and that that
key contains keys for each variable in the input files as well as the chunks. e.g.:

```
['.zattrs', '.zgroup',
'Grid/.zattrs', 'Grid/.zgroup', 'Grid/HQobservationTime/.zarray',
'Grid/HQobservationTime/.zattrs', 'Grid/HQobservationTime/0.0.0',
'Grid/HQprecipSource/.zarray', 'Grid/HQprecipSource/.zattrs',
'Grid/HQprecipSource/0.0.0', 'Grid/HQprecipitation/.zarray',
'Grid/HQprecipitation/.zattrs', 'Grid/HQprecipitation/0.0.0',
'Grid/HQprecipitation/0.1.0', 'Grid/IRkalmanFilterWeight/.zarray',
'Grid/IRkalmanFilterWeight/.zattrs', 'Grid/IRkalmanFilterWeight/0.0.0',
'Grid/IRprecipitation/.zarray', 'Grid/IRprecipitation/.zattrs',
'Grid/IRprecipitation/0.0.0', 'Grid/IRprecipitation/0.1.0', 'Grid/lat/.zarray',
'Grid/lat/.zattrs', 'Grid/lat/0', 'Grid/lat_bnds/.zarray',
'Grid/lat_bnds/.zattrs', 'Grid/lat_bnds/0.0', 'Grid/lon/.zarray',
'Grid/lon/.zattrs', 'Grid/lon/0', 'Grid/lon_bnds/.zarray',
'Grid/lon_bnds/.zattrs', 'Grid/lon_bnds/0.0', 'Grid/precipitationCal/.zarray',
'Grid/precipitationCal/.zattrs', 'Grid/precipitationCal/0.0.0',
'Grid/precipitationCal/0.1.0', 'Grid/precipitationQualityIndex/.zarray',
'Grid/precipitationQualityIndex/.zattrs',
'Grid/precipitationQualityIndex/0.0.0', 'Grid/precipitationQualityIndex/0.1.0',
'Grid/precipitationUncal/.zarray', 'Grid/precipitationUncal/.zattrs',
'Grid/precipitationUncal/0.0.0', 'Grid/precipitationUncal/0.1.0',
'Grid/probabilityLiquidPrecipitation/.zarray',
'Grid/probabilityLiquidPrecipitation/.zattrs',
'Grid/probabilityLiquidPrecipitation/0.0.0', 'Grid/randomError/.zarray',
'Grid/randomError/.zattrs', 'Grid/randomError/0.0.0', 'Grid/randomError/0.1.0',
'Grid/time/.zarray', 'Grid/time/.zattrs', 'Grid/time/0',
'Grid/time_bnds/.zarray', 'Grid/time_bnds/.zattrs', 'Grid/time_bnds/0.0']
```

Do this for both requests


## PR Acceptance Checklist
* [ X ] Jira ticket acceptance criteria met.
* [ n/a ] Tests added/updated and passing.
* [ ] Documentation updated (if needed).
