### PR TITLE
IP-244 - Update actions/upload-artifact to v4 due to v3 deprecation.

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -45,21 +45,21 @@ jobs:
 
       - name: Archive test results
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test result (Python 3.9)
           path: test_results.txt
 
       - name: Archive code coverage report (plain text)
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: code coverage report (plain text)
           path: coverage_report.txt
 
       - name: Archive code coverage report (HTML)
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: code coverage report (HTML)
           path: htmlcov/*


### PR DESCRIPTION
## Description

(Same as for `earthdata-varinfo`)

I received a deprecation notice for one of the actions we use to upload artefacts during our CI/CD runs (coverage reports and JUnit style test results output).

For more information see [here](https://github.blog/changelog/2024-12-05-deprecation-notice-github-pages-actions-to-require-artifacts-actions-v4-on-github-com/#:~:text=On%20January%2030%2C%202025%2C%20the,improved%20performance%20and%20new%20features.).

I don't think there are any breaking changes as we only use very basic options for the action and use unique names for each artefact we upload.

## Jira Issue ID

N/A

## Local Test Steps

N/A - just check there were artefacts saved to the workflow run for this PR.

## PR Acceptance Checklist

All are non-applicable. These changes are internal to our CI/CD workflows and will not require a release of any service code.

* ~~Jira ticket acceptance criteria met.~~
* ~~Tests added/updated and passing.~~
* ~~Documentation updated (if needed).~~
* ~~`version.txt` and `CHANGELOG.md` updated (if publishing a new release).~~